### PR TITLE
Bump version (v1.3.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # CHANGELOG
+## [v1.3.6](https://github.com/NubeIO/lora-raw/tree/v1.3.6) (2020-03-03)
+### Added
+- Upgrade mqtt-rest-bridge (listener issue fix)
+- Separate data and config files
+
 ## [v1.3.5](https://github.com/NubeIO/lora-raw/tree/v1.3.5) (2020-02-26)
 ### Added
 - MQTT publish value topic issue fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rubix-lora"
-version = "1.3.5"
+version = "1.3.6"
 description = "Rubix Lora interface"
 authors = ["NubeIO"]
 


### PR DESCRIPTION
### Includes

- Upgrade mqtt-rest-bridge (listener issue fix)
- Separate data and config files